### PR TITLE
Fix CSS linting issues

### DIFF
--- a/css/arcade.css
+++ b/css/arcade.css
@@ -50,10 +50,7 @@
   will-change: transform;
   content: '';
   position: absolute;
-  top: -4px;
-  left: -4px;
-  right: -4px;
-  bottom: -4px;
+  inset: -4px;
   border: 2px solid var(--primary-color, #3f51b5);
   border-radius: 30px;
   animation: pulse 1.5s infinite;
@@ -177,8 +174,7 @@
 
   /* Conteneur d'interface de jeu - corrections supplémentaires */
   .arcade-game-ui {
-    overflow-x: hidden !important;
-    overflow-y: auto !important;
+    overflow: hidden auto !important;
   }
 
   /* Correction globale tous éléments arcade sur mobile */
@@ -1050,7 +1046,7 @@ body.night .arcade-dev-banner,
   text-align: center;
 }
 
-.arcade-game-card .arcade-controls-help li:before {
+.arcade-game-card .arcade-controls-help li::before {
   content: '🎮 ';
   color: #4caf50;
   font-size: 1em;
@@ -1192,7 +1188,6 @@ body.night .arcade-dev-banner,
     min-height: auto !important;
     -webkit-line-clamp: unset !important;
     display: block !important;
-    -webkit-box-orient: unset !important;
     height: auto !important;
   }
 }

--- a/css/responsive-unified.css
+++ b/css/responsive-unified.css
@@ -201,8 +201,7 @@ img {
 
   /* Cartes en 2 colonnes avec meilleure gestion hauteur */
   .card-stack {
-    flex-direction: row;
-    flex-wrap: wrap;
+    flex-flow: row wrap;
     align-items: flex-start;
   }
 
@@ -675,6 +674,6 @@ img {
   .dev-note {
     white-space: normal;
     max-width: 90vw;
-    word-break: break-word;
+    overflow-wrap: break-word;
   }
 }


### PR DESCRIPTION
## Summary

- Remove deprecated `-webkit-box-orient` property in arcade.css
- Use `overflow` shorthand instead of separate `overflow-x` and `overflow-y` properties
- Replace individual position properties with `inset` shorthand
- Fix pseudo-element notation from `:before` to `::before`
- Replace deprecated `word-break: break-word` with `overflow-wrap: break-word`
- Use `flex-flow` shorthand instead of separate `flex-direction` and `flex-wrap` properties

## Test plan

- [ ] Verify that arcade games still display correctly
- [ ] Check responsive layouts still work properly
- [ ] Confirm flexbox layouts are unaffected
- [ ] Test pseudo-element styling is preserved

🤖 Generated with [Claude Code](https://claude.ai/code)