### PR TITLE
Fix Content Security Policy issue with Plausible Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,8 @@
     Suppressing static analysis warnings:
     sonarjs:S5725 - External scripts without integrity is acceptable for analytics services that auto-update
     -->
+    <!-- Plausible Analytics initialization -->
+    <script src="js/plausible-init.js"></script>
     <!-- eslint-disable-next-line sonarjs/no-script-without-integrity -- Analytics script auto-updates, integrity would break functionality -->
     <script
       defer
@@ -60,15 +62,6 @@
       src="https://plausible.io/js/script.js"
       crossorigin="anonymous"
     ></script>
-    <script>
-      window.plausible =
-        window.plausible ||
-        function () {
-          var queue = window.plausible.q || [];
-          window.plausible.q = queue;
-          queue.push(arguments);
-        };
-    </script>
   </head>
 
   <body>

--- a/js/plausible-init.js
+++ b/js/plausible-init.js
@@ -1,0 +1,12 @@
+/**
+ * Plausible Analytics Initialization
+ * This script initializes the Plausible analytics queue before the main script loads.
+ */
+
+window.plausible =
+  window.plausible ||
+  function () {
+    var queue = window.plausible.q || [];
+    window.plausible.q = queue;
+    queue.push(arguments);
+  };

--- a/js/plausible-init.js
+++ b/js/plausible-init.js
@@ -6,7 +6,7 @@
 window.plausible =
   window.plausible ||
   function () {
-    var queue = window.plausible.q || [];
+    const queue = window.plausible.q || [];
     window.plausible.q = queue;
     queue.push(arguments);
   };


### PR DESCRIPTION
## Summary

Resolves CSP violations that were preventing Plausible Analytics from loading correctly in browsers with strict security policies.

## Changes

- Move inline Plausible initialization script to external file `js/plausible-init.js`
- Update `index.html` to reference the external script instead of inline code
- Maintain compatibility with existing deployment pipeline and placeholder replacement

## Benefits

- Eliminates CSP violations for `script-src` directive
- Improves security compliance without functionality loss
- Ensures Plausible Analytics works consistently across all browsers
- Maintains existing caching and deployment behavior

## Test plan

- [x] Verify Plausible initialization works locally
- [x] Confirm no CSP errors in browser console  
- [x] Test that analytics events are properly queued
- [ ] Deploy and verify on production domain
- [ ] Confirm analytics data collection continues normally

## Technical Details

The inline script was blocked by CloudFront CSP policy `script-src 'self' https://plausible.io` which doesn't allow inline scripts. Moving to an external file resolves this as it's covered by the `'self'` directive.