### PR TITLE
Fix character creation video playback issue

### DIFF
--- a/js/userManager.js
+++ b/js/userManager.js
@@ -335,7 +335,7 @@ export const UserManager = {
     if (
       typeof VideoManager !== 'undefined' &&
       VideoManager.CHARACTER_VIDEOS &&
-      Object.prototype.hasOwnProperty.call(VideoManager.CHARACTER_VIDEOS, avatar)
+      VideoManager.CHARACTER_VIDEOS.has(avatar)
     ) {
       console.log(`🎬 Lancement vidéo d'introduction: ${avatar}`);
       // Callback pour sélectionner l'utilisateur après la vidéo
@@ -572,7 +572,10 @@ export const UserManager = {
 
         // 🎬 Ne sélectionner l'utilisateur que si aucune vidéo ne va être jouée
         // (createUser gère déjà la sélection via le callback vidéo)
-        if (typeof VideoManager === 'undefined' || !VideoManager.CHARACTER_VIDEOS[selectedAvatar]) {
+        if (
+          typeof VideoManager === 'undefined' ||
+          !VideoManager.CHARACTER_VIDEOS.has(selectedAvatar)
+        ) {
           this.selectUser(newName);
         }
       } else {

--- a/js/userManager.js
+++ b/js/userManager.js
@@ -572,10 +572,7 @@ export const UserManager = {
 
         // 🎬 Ne sélectionner l'utilisateur que si aucune vidéo ne va être jouée
         // (createUser gère déjà la sélection via le callback vidéo)
-        if (
-          typeof VideoManager === 'undefined' ||
-          !VideoManager.CHARACTER_VIDEOS.has(selectedAvatar)
-        ) {
+        if (!VideoManager?.CHARACTER_VIDEOS?.has(selectedAvatar)) {
           this.selectUser(newName);
         }
       } else {


### PR DESCRIPTION
## Summary
- Fixed character introduction videos not playing during user creation
- Replaced incorrect Object.prototype.hasOwnProperty usage with proper Map.has() method
- Videos now properly trigger when creating new characters with any avatar

## Test plan
- [x] Create new character with different avatars (fox, panda, unicorn, dragon, astronaut)
- [x] Verify introduction video plays for each character
- [x] Confirm video can be skipped or played to completion
- [x] Ensure user selection works correctly after video

🤖 Generated with [Claude Code](https://claude.ai/code)