### PR TITLE
Add default color theme option to customization screen

### DIFF
--- a/assets/translations/en.json
+++ b/assets/translations/en.json
@@ -93,6 +93,7 @@
   "clear_cache_confirm": "Clear cache and reload?",
   "clearing_cache_message": "Clearing cache...",
   "color_theme_applied": "{{themeName}} theme applied!",
+  "color_theme_default": "Classic",
   "color_theme_blue": "Space Blue",
   "color_theme_dark": "Night",
   "color_theme_green": "Nature",

--- a/assets/translations/es.json
+++ b/assets/translations/es.json
@@ -93,6 +93,7 @@
   "clear_cache_confirm": "¿Vaciar la caché y recargar?",
   "clearing_cache_message": "Limpiando la caché...",
   "color_theme_applied": "¡Tema {{themeName}} aplicado!",
+  "color_theme_default": "Clásico",
   "color_theme_blue": "Azul Espacial",
   "color_theme_dark": "Noche",
   "color_theme_green": "Naturaleza",

--- a/assets/translations/fr.json
+++ b/assets/translations/fr.json
@@ -97,6 +97,7 @@
   "clear_cache_confirm": "Vider le cache et recharger ?",
   "clearing_cache_message": "Nettoyage du cache...",
   "color_theme_applied": "Thème {{themeName}} appliqué !",
+  "color_theme_default": "Classique",
   "color_theme_blue": "Bleu Spatial",
   "color_theme_dark": "Nuit",
   "color_theme_green": "Nature",

--- a/index.html
+++ b/index.html
@@ -428,8 +428,17 @@
             <div class="color-theme-selector">
               <button
                 class="color-theme-btn active"
+                data-color-theme="default"
+                data-translate="color_theme_default"
+                aria-pressed="true"
+              >
+                🎨 Classique
+              </button>
+              <button
+                class="color-theme-btn"
                 data-color-theme="blue"
                 data-translate="color_theme_blue"
+                aria-pressed="false"
               >
                 🔷 Spatial
               </button>
@@ -437,6 +446,7 @@
                 class="color-theme-btn"
                 data-color-theme="green"
                 data-translate="color_theme_green"
+                aria-pressed="false"
               >
                 🌿 Nature
               </button>
@@ -444,6 +454,7 @@
                 class="color-theme-btn"
                 data-color-theme="orange"
                 data-translate="color_theme_orange"
+                aria-pressed="false"
               >
                 🔶 Orangé
               </button>
@@ -451,6 +462,7 @@
                 class="color-theme-btn"
                 data-color-theme="dark"
                 data-translate="color_theme_dark"
+                aria-pressed="false"
               >
                 🌙 Nuit
               </button>

--- a/js/components/customization.js
+++ b/js/components/customization.js
@@ -300,6 +300,12 @@ export const Customization = {
     gameState.colorTheme = themeName;
     localStorage.setItem('colorTheme', themeName);
 
+    document.querySelectorAll('.color-theme-btn').forEach(btn => {
+      const isActive = btn.dataset.colorTheme === themeName;
+      btn.classList.toggle('active', isActive);
+      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+
     // Retirer toutes les classes de thème de couleur
     document.body.classList.remove(
       'theme-pink',

--- a/js/components/customization.js
+++ b/js/components/customization.js
@@ -46,9 +46,9 @@ export const Customization = {
       currentImg.src = `assets/images/arcade/${current}_head_avatar_128x128.png`;
       currentImg.alt = current;
     }
-    document.querySelectorAll('.avatar-btn').forEach(btn => {
+    for (const btn of document.querySelectorAll('.avatar-btn')) {
       btn.classList.toggle('active', btn.dataset.avatar === (gameState.avatar || 'fox'));
-    });
+    }
 
     // Mettre à jour le champ de surnom
     const nicknameInput = document.getElementById('nickname-input');
@@ -82,7 +82,7 @@ export const Customization = {
         const btn = document.createElement('button');
         btn.id = 'clear-cache-btn';
         btn.className = 'btn btn-sm-desktop clear-cache-btn';
-        btn.setAttribute('data-translate', 'clear_cache_button');
+        btn.dataset.translate = 'clear_cache_button';
         btn.title = getTranslation('clear_cache_button') || 'Vider le cache';
         btn.style.marginLeft = '8px';
         btn.style.opacity = '0.75';
@@ -102,7 +102,7 @@ export const Customization = {
     document.querySelectorAll('.avatar-btn');
 
     // Sélection d'avatar
-    document.querySelectorAll('.avatar-btn:not(.locked)').forEach(btn => {
+    for (const btn of document.querySelectorAll('.avatar-btn:not(.locked)')) {
       // Supprimer l'ancien écouteur s'il existe pour éviter les doublons
       const newBtn = btn.cloneNode(true);
       btn.parentNode.replaceChild(newBtn, btn);
@@ -113,9 +113,9 @@ export const Customization = {
         startBackgroundRotation(avatarName); // Rotation auto après changement d'avatar
 
         // Mettre à jour la sélection visuelle
-        document.querySelectorAll('.avatar-btn').forEach(b => {
-          b.classList.toggle('active', b.dataset.avatar === avatarName);
-        });
+        for (const avatarBtn of document.querySelectorAll('.avatar-btn')) {
+          avatarBtn.classList.toggle('active', avatarBtn.dataset.avatar === avatarName);
+        }
 
         // Mettre à jour l'image d'avatar actuel
         const currentImg = document.getElementById('current-avatar-img');
@@ -130,7 +130,7 @@ export const Customization = {
         UserState.updateUserData(userData);
         console.log(`🎨 Avatar "${avatarName}" sauvegardé automatiquement`);
       });
-    });
+    }
 
     // Ajouter le clavier virtuel pour le surnom
     const nicknameInput = document.getElementById('nickname-input');
@@ -192,7 +192,7 @@ export const Customization = {
     }
 
     // Sélection thème d'aventure
-    document.querySelectorAll('.theme-btn').forEach(btn => {
+    for (const btn of document.querySelectorAll('.theme-btn')) {
       // Supprimer l'ancien écouteur s'il existe
       const newBtn = btn.cloneNode(true);
       btn.parentNode.replaceChild(newBtn, btn);
@@ -201,22 +201,22 @@ export const Customization = {
         // Mettre à jour l'état global
         gameState.theme = themeName;
         // Mettre à jour la sélection visuelle
-        document.querySelectorAll('.theme-btn').forEach(b => {
-          b.classList.toggle('active', b.dataset.theme === themeName);
-        });
+        for (const themeBtn of document.querySelectorAll('.theme-btn')) {
+          themeBtn.classList.toggle('active', themeBtn.dataset.theme === themeName);
+        }
         // Note: updateTheme n'existe pas, la sauvegarde se fait dans saveCustomization
       });
-    });
+    }
 
     // Sélection thème de couleurs
-    document.querySelectorAll('.color-theme-btn').forEach(btn => {
+    for (const btn of document.querySelectorAll('.color-theme-btn')) {
       // Supprimer l'ancien écouteur s'il existe
       const newBtn = btn.cloneNode(true);
       btn.parentNode.replaceChild(newBtn, btn);
       newBtn.addEventListener('click', () => {
         this.updateColorTheme(newBtn.dataset.colorTheme);
       });
-    });
+    }
 
     // Tâche 4.2: Ajouter navigation clavier par flèches aux sélecteurs
     addArrowKeyNavigation(document.querySelector('.avatar-selector'), '.avatar-btn:not(.locked)');
@@ -300,11 +300,11 @@ export const Customization = {
     gameState.colorTheme = themeName;
     localStorage.setItem('colorTheme', themeName);
 
-    document.querySelectorAll('.color-theme-btn').forEach(btn => {
+    for (const btn of document.querySelectorAll('.color-theme-btn')) {
       const isActive = btn.dataset.colorTheme === themeName;
       btn.classList.toggle('active', isActive);
-      btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-    });
+      btn.ariaPressed = isActive ? 'true' : 'false';
+    }
 
     // Retirer toutes les classes de thème de couleur
     document.body.classList.remove(

--- a/js/core/theme.js
+++ b/js/core/theme.js
@@ -16,11 +16,11 @@ export function initThemes() {
   if (savedColorTheme !== 'default') {
     document.body.classList.add('theme-' + savedColorTheme);
   }
-  document.querySelectorAll('.color-theme-btn').forEach(btn => {
+  for (const btn of document.querySelectorAll('.color-theme-btn')) {
     const isActive = btn.dataset.colorTheme === savedColorTheme;
     btn.classList.toggle('active', isActive);
-    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
-  });
+    btn.ariaPressed = isActive ? 'true' : 'false';
+  }
   applyHighContrastMode(localStorage.getItem('highContrastEnabled') === 'true');
   applyFontSize(localStorage.getItem('fontSize') || 'medium');
 }
@@ -39,14 +39,16 @@ export function updateVolume(newVolume) {
     TopBar.updateVolumeControls(newVolume, newVolume === 0);
   } catch (e) {
     void e;
-    document.querySelectorAll('.mute-btn').forEach(btn => {
+    for (const btn of document.querySelectorAll('.mute-btn')) {
       btn.textContent = newVolume > 0 ? '🔊' : '🔇';
       const key = newVolume > 0 ? 'mute_button_label_on' : 'mute_button_label_off';
       const t = getTranslation(key);
       const missing = typeof t === 'string' && t.startsWith('[') && t.endsWith(']');
       btn.title = missing ? (newVolume > 0 ? 'Couper le son' : 'Activer le son') : t;
-    });
-    document.querySelectorAll('.volume-slider').forEach(slider => (slider.value = newVolume));
+    }
+    for (const slider of document.querySelectorAll('.volume-slider')) {
+      slider.value = newVolume;
+    }
   }
 
   localStorage.setItem('volume', newVolume);
@@ -67,15 +69,15 @@ export function applyFontSize(size) {
   if (['small', 'medium', 'large'].includes(size)) {
     document.body.classList.add(`font-size-${size}`);
     localStorage.setItem('fontSize', size);
-    document.querySelectorAll('.font-size-btn').forEach(btn => {
+    for (const btn of document.querySelectorAll('.font-size-btn')) {
       btn.classList.toggle('active', btn.dataset.size === size);
-    });
+    }
   } else {
     document.body.classList.add('font-size-medium');
     localStorage.setItem('fontSize', 'medium');
-    document.querySelectorAll('.font-size-btn').forEach(btn => {
+    for (const btn of document.querySelectorAll('.font-size-btn')) {
       btn.classList.toggle('active', btn.dataset.size === 'medium');
-    });
+    }
   }
 }
 

--- a/js/core/theme.js
+++ b/js/core/theme.js
@@ -17,7 +17,9 @@ export function initThemes() {
     document.body.classList.add('theme-' + savedColorTheme);
   }
   document.querySelectorAll('.color-theme-btn').forEach(btn => {
-    btn.classList.toggle('active', btn.dataset.colorTheme === savedColorTheme);
+    const isActive = btn.dataset.colorTheme === savedColorTheme;
+    btn.classList.toggle('active', isActive);
+    btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
   });
   applyHighContrastMode(localStorage.getItem('highContrastEnabled') === 'true');
   applyFontSize(localStorage.getItem('fontSize') || 'medium');

--- a/js/core/theme.js
+++ b/js/core/theme.js
@@ -25,6 +25,15 @@ export function initThemes() {
   applyFontSize(localStorage.getItem('fontSize') || 'medium');
 }
 
+function getMuteButtonTitle(isMuted, translation) {
+  const isMissingTranslation =
+    typeof translation === 'string' && translation.startsWith('[') && translation.endsWith(']');
+  if (isMissingTranslation) {
+    return isMuted ? 'Activer le son' : 'Couper le son';
+  }
+  return translation;
+}
+
 function updateMuteButtons(newVolume) {
   const numericVolume = Number(newVolume);
   const isMuted = Number.isNaN(numericVolume) ? false : numericVolume === 0;
@@ -32,13 +41,7 @@ function updateMuteButtons(newVolume) {
     btn.textContent = isMuted ? '🔇' : '🔊';
     const key = isMuted ? 'mute_button_label_off' : 'mute_button_label_on';
     const translation = getTranslation(key);
-    const isMissingTranslation =
-      typeof translation === 'string' && translation.startsWith('[') && translation.endsWith(']');
-    let fallbackTitle = 'Couper le son';
-    if (isMuted) {
-      fallbackTitle = 'Activer le son';
-    }
-    btn.title = isMissingTranslation ? fallbackTitle : translation;
+    btn.title = getMuteButtonTitle(isMuted, translation);
   }
 }
 

--- a/js/core/theme.js
+++ b/js/core/theme.js
@@ -27,7 +27,7 @@ export function initThemes() {
 
 function updateMuteButtons(newVolume) {
   const numericVolume = Number(newVolume);
-  const isMuted = !Number.isNaN(numericVolume) ? numericVolume === 0 : false;
+  const isMuted = Number.isNaN(numericVolume) ? false : numericVolume === 0;
   for (const btn of document.querySelectorAll('.mute-btn')) {
     btn.textContent = isMuted ? '🔇' : '🔊';
     const key = isMuted ? 'mute_button_label_off' : 'mute_button_label_on';
@@ -55,7 +55,7 @@ function updateVolumeControlsFallback(newVolume) {
 
 export function updateVolume(newVolume) {
   const numericVolume = Number(newVolume);
-  const isMuted = !Number.isNaN(numericVolume) ? numericVolume === 0 : newVolume === 0;
+  const isMuted = Number.isNaN(numericVolume) ? newVolume === 0 : numericVolume === 0;
 
   gameState.volume = newVolume;
   gameState.muted = isMuted;

--- a/js/core/theme.js
+++ b/js/core/theme.js
@@ -25,6 +25,29 @@ export function initThemes() {
   applyFontSize(localStorage.getItem('fontSize') || 'medium');
 }
 
+function updateMuteButtons(newVolume) {
+  const isMuted = Number(newVolume) === 0;
+  for (const btn of document.querySelectorAll('.mute-btn')) {
+    btn.textContent = isMuted ? '🔇' : '🔊';
+    const key = isMuted ? 'mute_button_label_off' : 'mute_button_label_on';
+    const translation = getTranslation(key);
+    const isMissingTranslation =
+      typeof translation === 'string' && translation.startsWith('[') && translation.endsWith(']');
+    btn.title = isMissingTranslation ? (isMuted ? 'Activer le son' : 'Couper le son') : translation;
+  }
+}
+
+function updateVolumeSliders(newVolume) {
+  for (const slider of document.querySelectorAll('.volume-slider')) {
+    slider.value = newVolume;
+  }
+}
+
+function updateVolumeControlsFallback(newVolume) {
+  updateMuteButtons(newVolume);
+  updateVolumeSliders(newVolume);
+}
+
 export function updateVolume(newVolume) {
   gameState.volume = newVolume;
   gameState.muted = newVolume === 0;
@@ -39,16 +62,7 @@ export function updateVolume(newVolume) {
     TopBar.updateVolumeControls(newVolume, newVolume === 0);
   } catch (e) {
     void e;
-    for (const btn of document.querySelectorAll('.mute-btn')) {
-      btn.textContent = newVolume > 0 ? '🔊' : '🔇';
-      const key = newVolume > 0 ? 'mute_button_label_on' : 'mute_button_label_off';
-      const t = getTranslation(key);
-      const missing = typeof t === 'string' && t.startsWith('[') && t.endsWith(']');
-      btn.title = missing ? (newVolume > 0 ? 'Couper le son' : 'Activer le son') : t;
-    }
-    for (const slider of document.querySelectorAll('.volume-slider')) {
-      slider.value = newVolume;
-    }
+    updateVolumeControlsFallback(newVolume);
   }
 
   localStorage.setItem('volume', newVolume);

--- a/js/core/theme.js
+++ b/js/core/theme.js
@@ -26,14 +26,19 @@ export function initThemes() {
 }
 
 function updateMuteButtons(newVolume) {
-  const isMuted = Number(newVolume) === 0;
+  const numericVolume = Number(newVolume);
+  const isMuted = !Number.isNaN(numericVolume) ? numericVolume === 0 : false;
   for (const btn of document.querySelectorAll('.mute-btn')) {
     btn.textContent = isMuted ? '🔇' : '🔊';
     const key = isMuted ? 'mute_button_label_off' : 'mute_button_label_on';
     const translation = getTranslation(key);
     const isMissingTranslation =
       typeof translation === 'string' && translation.startsWith('[') && translation.endsWith(']');
-    btn.title = isMissingTranslation ? (isMuted ? 'Activer le son' : 'Couper le son') : translation;
+    let fallbackTitle = 'Couper le son';
+    if (isMuted) {
+      fallbackTitle = 'Activer le son';
+    }
+    btn.title = isMissingTranslation ? fallbackTitle : translation;
   }
 }
 
@@ -49,8 +54,11 @@ function updateVolumeControlsFallback(newVolume) {
 }
 
 export function updateVolume(newVolume) {
+  const numericVolume = Number(newVolume);
+  const isMuted = !Number.isNaN(numericVolume) ? numericVolume === 0 : newVolume === 0;
+
   gameState.volume = newVolume;
-  gameState.muted = newVolume === 0;
+  gameState.muted = isMuted;
 
   try {
     AudioManager.setVolume(newVolume);
@@ -59,7 +67,7 @@ export function updateVolume(newVolume) {
   }
 
   try {
-    TopBar.updateVolumeControls(newVolume, newVolume === 0);
+    TopBar.updateVolumeControls(newVolume, isMuted);
   } catch (e) {
     void e;
     updateVolumeControlsFallback(newVolume);


### PR DESCRIPTION
## Summary
- add a default color theme button so players can return to the base palette
- sync button active/aria states with the saved color theme
- localize the new label across French, English, and Spanish

## Testing
- npm run format