### PR TITLE
Fix cache configuration alignment between CDN and application

### DIFF
--- a/js/cache-updater.js
+++ b/js/cache-updater.js
@@ -123,15 +123,15 @@ export function clearCacheAndReload() {
         // que le cache a été vidé et qu'il faut forcer le rechargement de toutes les images
         localStorage.setItem('cache_cleared_timestamp', APP_VERSION);
 
-        // Ajouter un paramètre unique pour contourner le cache du navigateur
+        // Ajouter un paramètre versionné (utilise la whitelist CDN)
         const loc = typeof globalThis !== 'undefined' ? globalThis.location : window.location;
-        loc.href = loc.pathname + '?fresh=' + APP_VERSION;
+        loc.href = `${loc.pathname}?${VERSION_PARAM}`;
       });
   } else {
     // Pour les navigateurs qui ne supportent pas l'API Cache
     localStorage.setItem('cache_cleared_timestamp', APP_VERSION);
     const loc = typeof globalThis !== 'undefined' ? globalThis.location : window.location;
-    loc.href = loc.pathname + '?fresh=' + APP_VERSION;
+    loc.href = `${loc.pathname}?${VERSION_PARAM}`;
   }
 }
 


### PR DESCRIPTION
## Summary

- Fix critical service worker caching issue preventing updates from deploying
- Align CloudFront TTL configuration with application cache-busting strategy
- Improve cache coherence between CDN headers and browser behavior

## Changes

### Infrastructure (terraform/cloudfront.tf)
- Add dedicated cache behavior for `/sw.js` with TTL=0 to prevent update blocking
- Create separate response header policies for HTML vs assets vs default resources
- Replace hardcoded TTL values with configurable variables from `variables.tf`
- Apply appropriate cache headers: `no-store` for HTML, long TTL for versioned assets

### Application (js/cache-updater.js)
- Fix manual cache clearing to use whitelisted `v` parameter instead of ignored `fresh`
- Ensure cache-busting URLs work with CDN configuration

## Impact

- **Critical**: Service worker updates now deploy immediately instead of being cached for 7 days
- **Major**: HTML pages no longer cached for 30 days in browsers despite 24h CDN TTL
- **Improved**: Manual cache clearing now works correctly with CDN
- **Maintainable**: TTL values now configurable via Terraform variables

## Test Plan

- [ ] Deploy Terraform changes to staging environment
- [ ] Verify headers with curl tests for `/sw.js`, `/`, and CSS/JS assets
- [ ] Test manual cache clearing functionality
- [ ] Deploy version bump to validate immediate propagation
- [ ] Monitor CloudFront hit/miss metrics post-deployment