### PR TITLE
Improve speech voice selection to include remote high-quality voices

### DIFF
--- a/js/speech.js
+++ b/js/speech.js
@@ -148,6 +148,7 @@ function findPreferredVoice(voiceCandidates, langPrefix) {
     },
   };
 
+  // eslint-disable-next-line security/detect-object-injection -- False positive: langPrefix comes from lang.split('-')[0] with controlled values ('fr'|'en'|'es')
   const preferred = preferredVoices[langPrefix] || { local: [], remote: [] };
 
   // First, try to find a preferred local voice (better reliability, no network)


### PR DESCRIPTION
## Summary

Fixes the voice selection logic to properly prioritize high-quality voices across all available options (both local and remote).

## Changes

- **Search all voices for preferred options**: Previously, the code only searched within local voices, which excluded Google voices (marked as remote with `localService: false`). Now searches across all available voices.
- **Filter low-quality voices**: Excludes known poor-quality voices (eSpeak, Apple Eloquence, novelty voices) based on web-speech-recommended-voices research.
- **Prioritize intelligently**: 
  1. Local high-quality voices (Amelie, Alex, etc.) - best for offline reliability
  2. Remote high-quality voices (Google français, etc.) - excellent quality when online
  3. Any local voice - fallback for offline use
  4. Any remote voice - last resort
- **Accept regional variants**: Properly handles fr-CA, es-US when exact locale (fr-FR, es-ES) is unavailable.

## Testing

- ✅ All existing tests pass
- ✅ ESLint validation
- ✅ Code formatting verified

## Fixes

Resolves the issue where Google voices were never selected despite being listed in preferences, resulting in fallback to lower-quality system voices on Chrome/Edge.