### PR TITLE
fix: prevent page scroll during arcade games with arrow keys

### DIFF
--- a/js/arcade.js
+++ b/js/arcade.js
@@ -45,10 +45,16 @@ export function setArcadeActive(v) {
 }
 // La fonction shoot sera définie plus bas, mais doit être accessible globalement
 export function arcadeKeyDown(e) {
+  if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+    e.preventDefault(); // Empêcher le scroll de la page
+  }
   if (e.key === 'ArrowLeft') arcadeControls.leftPressed = true;
   if (e.key === 'ArrowRight') arcadeControls.rightPressed = true;
 }
 export function arcadeKeyUp(e) {
+  if (e.key === 'ArrowLeft' || e.key === 'ArrowRight') {
+    e.preventDefault(); // Empêcher le scroll de la page
+  }
   if (e.key === 'ArrowLeft') arcadeControls.leftPressed = false;
   if (e.key === 'ArrowRight') arcadeControls.rightPressed = false;
 }

--- a/js/multimiam-controls.js
+++ b/js/multimiam-controls.js
@@ -18,22 +18,27 @@ export function initPacmanControls(game) {
 
     switch (e.key) {
       case 'ArrowUp':
+        e.preventDefault(); // Empêcher le scroll de la page
         newDirection = 'UP';
         directionChanged = true;
         break;
       case 'ArrowDown':
+        e.preventDefault(); // Empêcher le scroll de la page
         newDirection = 'DOWN';
         directionChanged = true;
         break;
       case 'ArrowLeft':
+        e.preventDefault(); // Empêcher le scroll de la page
         newDirection = 'LEFT';
         directionChanged = true;
         break;
       case 'ArrowRight':
+        e.preventDefault(); // Empêcher le scroll de la page
         newDirection = 'RIGHT';
         directionChanged = true;
         break;
       case ' ':
+        e.preventDefault(); // Empêcher le scroll de la page
         if (game.gameOver) {
           game.start();
         } else {

--- a/js/multisnake.js
+++ b/js/multisnake.js
@@ -466,26 +466,31 @@ class SnakeGame {
   handleKeyDown(e) {
     switch (e.key) {
       case 'ArrowUp':
+        e.preventDefault(); // Empêcher le scroll de la page
         if (this.direction.y !== 1) {
           this.nextDirection = { x: 0, y: -1 };
         }
         break;
       case 'ArrowDown':
+        e.preventDefault(); // Empêcher le scroll de la page
         if (this.direction.y !== -1) {
           this.nextDirection = { x: 0, y: 1 };
         }
         break;
       case 'ArrowLeft':
+        e.preventDefault(); // Empêcher le scroll de la page
         if (this.direction.x !== 1) {
           this.nextDirection = { x: -1, y: 0 };
         }
         break;
       case 'ArrowRight':
+        e.preventDefault(); // Empêcher le scroll de la page
         if (this.direction.x !== -1) {
           this.nextDirection = { x: 1, y: 0 };
         }
         break;
       case ' ':
+        e.preventDefault(); // Empêcher le scroll de la page
         if (this.gameOver) {
           this.start();
         }


### PR DESCRIPTION
## Summary
Add preventDefault() to arrow key and space key handlers in arcade games to prevent the browser's default scroll behavior.

## Problem
When playing arcade games (Multimiam, Multisnake, Space Invasion), using arrow keys would trigger page scrolling, making the games completely unplayable.

## Solution
Added `e.preventDefault()` calls in keyboard event handlers for all arcade games:
- Arrow keys (Up, Down, Left, Right)
- Space bar

## Changes
- `js/multimiam-controls.js`: Add preventDefault() for arrow keys and space
- `js/multisnake.js`: Add preventDefault() for arrow keys and space  
- `js/arcade.js`: Add preventDefault() for left/right arrow keys

## Testing
✅ Tested in Chrome - arrow keys no longer scroll the page during gameplay
✅ Game controls work correctly
✅ All three arcade games affected by the fix

## Impact
- Fixes critical playability issue
- No breaking changes
- Improves user experience significantly