### PR TITLE
fix(a11y,ui): disable word numbers for +/− and align static pages design

### DIFF
--- a/js/modes/AdventureMode.js
+++ b/js/modes/AdventureMode.js
@@ -381,9 +381,13 @@ export class AdventureMode extends GameMode {
         }).answer
     );
 
+    // Afficher les nombres en lettres uniquement pour × et ÷ (pas pour + et −)
+    const operator = this.state.currentQuestion?.operator;
+    const shouldUseWords = Math.random() < 0.2 && ['×', '÷'].includes(operator);
+
     return options.map(value => ({
       value: value,
-      display: Math.random() < 0.2 ? numberToWords(value) : value.toString(),
+      display: shouldUseWords ? numberToWords(value) : value.toString(),
     }));
   }
 

--- a/js/modes/ChallengeMode.js
+++ b/js/modes/ChallengeMode.js
@@ -323,9 +323,13 @@ export class ChallengeMode extends GameMode {
       () => (Math.floor(Math.random() * 10) + 1) * (Math.floor(Math.random() * 10) + 1)
     );
 
+    // Afficher les nombres en lettres uniquement pour × et ÷ (pas pour + et −)
+    const operator = this.state.currentQuestion?.operator;
+    const shouldUseWords = Math.random() < 0.2 && ['×', '÷'].includes(operator);
+
     return options.map(value => ({
       value: value,
-      display: Math.random() < 0.2 ? numberToWords(value) : value.toString(),
+      display: shouldUseWords ? numberToWords(value) : value.toString(),
     }));
   }
 

--- a/js/modes/QuizMode.js
+++ b/js/modes/QuizMode.js
@@ -177,9 +177,13 @@ export class QuizMode extends GameMode {
           () => (Math.floor(Math.random() * 10) + 1) * (Math.floor(Math.random() * 10) + 1)
         );
 
+        // Afficher les nombres en lettres uniquement pour × et ÷ (pas pour + et −)
+        const operator = this.state.currentQuestion?.operator;
+        const shouldUseWords = Math.random() < 0.2 && ['×', '÷'].includes(operator);
+
         return options.map(value => ({
           value: value,
-          display: Math.random() < 0.2 ? numberToWords(value) : value.toString(),
+          display: shouldUseWords ? numberToWords(value) : value.toString(),
         }));
       }
       case 'true_false':

--- a/package-lock.json
+++ b/package-lock.json
@@ -99,7 +99,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.3.tgz",
       "integrity": "sha512-hyrN8ivxfvJ4i0fIJuV4EOlV0WDMz5Ui4StRTgVaAvWeiRCilXgwVvxJKtFQ3TKtHgJscB2YiXKGNJuVwhQMtA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1812,7 +1811,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1835,7 +1833,6 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3379,7 +3376,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -3403,7 +3399,6 @@
       "integrity": "sha512-s5vvxXPVdjqS3kTLKMeBMvop9hbWkwzBpu+mUO2M7sZtlkyDJGwFe33wRKnbaYDo8ExRVBIIdwIGrqpxHuKttA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       },
@@ -3417,7 +3412,6 @@
       "integrity": "sha512-OOCM2C/QIURhJMuKaekP3TRBxBKxG/TWWA0TL2J6nXUtDnuCtccy49LUJF8xPFXMX+0LMcxFpCo8M9cGY1W6rQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "1.28.0"
       },
@@ -3900,7 +3894,6 @@
       "integrity": "sha512-5UxZqiAgLYGFjS4s9qm5mBVo433u+dSPUFWVWXmLAD4wB65oMCoXaJP1KJa9DIYYMeHu3z4BZcStG3LC593cWA==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/semantic-conventions": "1.28.0"
@@ -3928,7 +3921,6 @@
       "integrity": "sha512-jVPgBbH1gCy2Lb7X0AVQ8XAfgg0pJ4nvl8/IiQA6nxOsPvS+0zMJaFSs2ltXe0J6C8dqjcnpyqINDJmU30+uOg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "1.30.1",
         "@opentelemetry/resources": "1.30.1",
@@ -3957,7 +3949,6 @@
       "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -4544,7 +4535,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       },
@@ -4568,7 +4558,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14 || ^16 || >=18"
       }
@@ -4836,7 +4825,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5447,7 +5435,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.2",
         "caniuse-lite": "^1.0.30001741",
@@ -6151,8 +6138,7 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1495869.tgz",
       "integrity": "sha512-i+bkd9UYFis40RcnkW7XrOprCujXRAHg62IVh/Ah3G8MmNXpCGt1m0dTFhSdx/AVs8XEMbdOGRwdkR1Bcta8AA==",
       "dev": true,
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -6338,7 +6324,6 @@
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -8387,7 +8372,6 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -9343,7 +9327,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9390,7 +9373,6 @@
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
       "integrity": "sha512-8sLjZwK0R+JlxlYcTuVnyT2v+htpdrjDOKuMcOVdYjt52Lh8hWRYpxBPoKx/Zg+bcjc3wx6fmQevMmUztS/ccA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -9947,7 +9929,6 @@
       "integrity": "sha512-78E9voJHwnXQMiQdiqswVLZwJIzdBKJ1GdI5Zx6XwoFKUIk09/sSrr+05QFzvYb8q6Y9pPV45zzDuYa3907TZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },


### PR DESCRIPTION
## Summary
- Disable word number display (e.g., "douze") for addition and subtraction operations - only show for × and ÷
- Align static pages (modes.html, parents.html) with the playful candy-colored design system
- Update meta descriptions to reflect multi-operation support (×, +, −, ÷)

## Test plan
- [ ] Verify word numbers only appear in Quiz/Challenge/Adventure for × and ÷ operations
- [ ] Check static pages styling matches main app design
- [ ] Confirm all 215 tests pass
- [ ] Verify lint and format checks pass