### PR TITLE
chore: bump version to v19

### DIFF
--- a/js/cache-updater.js
+++ b/js/cache-updater.js
@@ -4,7 +4,7 @@
  */
 
 // Version globale de l'application - doit correspondre à sw.js
-export const APP_VERSION = 'v18';
+export const APP_VERSION = 'v19';
 export const VERSION_PARAM = `v=${APP_VERSION}`;
 
 const runtime = globalThis;

--- a/sw.js
+++ b/sw.js
@@ -5,7 +5,7 @@
 // - Translations JSON: stale-while-revalidate
 // - JS/CSS: network-first with cache fallback (updates take precedence)
 
-const VERSION = 'v18'; // bump to trigger client update
+const VERSION = 'v19'; // bump to trigger client update
 const OFFLINE_CACHE = `leapmultix-offline-${VERSION}`;
 const RUNTIME_CACHE = `leapmultix-runtime-${VERSION}`;
 const OFFLINE_URL = '/offline.html';


### PR DESCRIPTION
## Summary
- Bump service worker version from v18 to v19
- Bump cache-updater version from v18 to v19

Forces cache refresh for users after recent changes (word numbers fix, static pages design).

## Test plan
- [ ] Verify sw.js and cache-updater.js have matching versions
- [ ] Deploy with `./deploy.sh` and confirm cache invalidation works